### PR TITLE
Fix publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "typings": "./lib/index",
   "scripts": {
     "test": "make ci-test",
-    "build": "make lib"
+    "prepublish": "make lib"
   },
   "engines": {
     "node": "^8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@steemit/rpc-auth",
-  "version": "1.0.0",
+  "description": "JSON-RPC 2.0 authentication using steem blockchain authorities",
+  "version": "1.0.1",
   "license": "MIT",
   "main": "./lib/index",
   "typings": "./lib/index",


### PR DESCRIPTION
Prepublish hook was missing so compiled `lib/` didn't get included in package, fixed here.