### PR TITLE
Fix publish again

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "test": "make ci-test",
     "prepublish": "make lib"
   },
+  "files": [
+    "lib/*"
+  ],
   "engines": {
     "node": "^8"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@steemit/rpc-auth",
   "description": "JSON-RPC 2.0 authentication using steem blockchain authorities",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "main": "./lib/index",
   "typings": "./lib/index",


### PR DESCRIPTION
`npm publish` uses `.gitignore` if `files` are not present in package.json